### PR TITLE
Add get_mediabox function

### DIFF
--- a/src/eg_pdf.erl
+++ b/src/eg_pdf.erl
@@ -43,6 +43,7 @@
          inches/1,
          get_page_no/1,
          get_state/1,
+         get_mediabox/1,
          get_string_width/3, get_string_width/4,
          grid/3,
 	 header/0,
@@ -145,6 +146,11 @@ delete(PID)->
 
 get_state(PID) ->
   gen_server:call(PID, {get_state}).
+
+%% @doc return the mediabox set on the server
+
+get_mediabox(PID) ->
+  gen_server:call(PID, {get_mediabox}).
 
 %% @doc Add current page context to PDF document and start on a new page 
 %% Note page 1 is already created  by default and  current page set 
@@ -643,8 +649,10 @@ handle_call({export}, _From, [PDFC, Stream]) ->
 	    {reply, {export, PDF, PageNo}, [PDFC, Stream]};
 	    
 handle_call({get_state}, _From, [PDFC, Stream]) ->	        
-	    {reply, [PDFC, Stream], [PDFC, Stream]}.
+	    {reply, [PDFC, Stream], [PDFC, Stream]};
 
+handle_call({get_mediabox}, _From, [PDFC, Stream]) ->
+      {reply, PDFC#pdfContext.mediabox, [PDFC, Stream]}.
 
 %%--------------------------------------------------------------------
 %% Function: handle_cast(Msg, State) -> {noreply, State} |

--- a/test/eg1_test.erl
+++ b/test/eg1_test.erl
@@ -31,6 +31,7 @@ run_test()->
     ?debugMsg("Begin Test"),
     PDF = eg_pdf:new(),
     eg_pdf:set_pagesize(PDF,a4),
+    ?assert(eg_pdf:get_mediabox(PDF) =:= {0, 0, 595, 842}),
     eg_pdf:set_author(PDF,"Mikael Karlsson"),
     eg_pdf:set_title(PDF, "Test of PDF API"),
     eg_pdf:set_subject(PDF,"PDF is cool, but Erlang is cooler"),


### PR DESCRIPTION
Add a function that allows us to get the mediabox directly without having to pattern-match on the whole state record.

These PRs are all related:
https://github.com/sendle/sendle/pull/4443
https://github.com/sendle/sendle-couriers-ex/pull/958
https://github.com/sendle/sendle_model/pull/97
https://github.com/sendle/erlguten/pull/3