### PR TITLE
Fix dialyzer warnings from eg_pdf:image/4

### DIFF
--- a/src/eg_pdf.erl
+++ b/src/eg_pdf.erl
@@ -549,7 +549,7 @@ image1(PID, FilePath, {height, H}) ->
 image1(PID, FilePath, {W, H}) when is_integer(W), is_integer(H)->
     image1(PID, FilePath, {size,{W,H}});
 image1(PID, FilePath, {size,Size})->
-    case file:open(FilePath,read) of
+    case file:open(FilePath,[read]) of
 	{ok,IO} -> 
 	    file:close(IO),
 	    gen_server:cast(PID, {image, FilePath, Size});


### PR DESCRIPTION
Currently getting dialyzer warnings in `SendleCouriers.PDF.image/3` due to `:eg_pdf.image/4`. Dialyzer is showing it's cryptically "useful" error `Function image/3 has no return local return`.

Tracked it down to `eg_pdf:image/4` calling `file:open(FilePath, read)`. However, the type spec for `file:open/2` is actually for the modes argument to accept a list, rather than a singular atom. Passing a single atom _works_, but isn't correct, and causes downstream type spec errors due to violating the `file:open/2` type spec.

Fix is to just wrap the `read` mode atom as a list.

### Before

<img width="483" alt="image" src="https://user-images.githubusercontent.com/27223/188523741-16b2c865-38e0-4877-b201-25ff38d11534.png">

(elixir-ls support with dialyzer in NeoVim is awesome - you should set it up 😁)

### After

<img width="483" alt="image" src="https://user-images.githubusercontent.com/27223/188522745-98446d7a-9ddf-4643-816b-c6dff4a0c18a.png">
