### PR TITLE
Allow non-integer scaling

### DIFF
--- a/src/eg_pdf.erl
+++ b/src/eg_pdf.erl
@@ -448,7 +448,7 @@ text_transform(PID, A, B, C, D, E, F)->
 translate(PID, X, Y)->
     append_stream(PID, eg_pdf_op:translate(X,Y)).
 
-scale(PID, ScaleX, ScaleY) when is_integer(ScaleX), is_integer(ScaleY)->
+scale(PID, ScaleX, ScaleY)->
     append_stream(PID, eg_pdf_op:scale(ScaleX, ScaleY)).
 
 rotate(PID, Angle)->

--- a/src/eg_pdf_op.erl
+++ b/src/eg_pdf_op.erl
@@ -320,7 +320,7 @@ text_transform(A, B, C, D, E, F)->
 translate(X,Y)->
     transform(1,0,0,1,X,Y).
 
-scale(ScaleX, ScaleY) when is_integer(ScaleX), is_integer(ScaleY)->
+scale(ScaleX, ScaleY)->
     transform(ScaleX, 0, 0, ScaleY, 0, 0).
 
 rotate(90)->  " 0 1 -1 0 0 0 cm\n";


### PR DESCRIPTION
There is nothing in the PDF standard that forces scaling to be integers. It is just a transform matrix and that can be floats as well.

https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf

Page 118, §8.3.3
"Scaling shall be obtained by [ sx 0 0 sy 0 0 ]."
