### PR TITLE
SVG support

### DIFF
--- a/src/eg_pdf.erl
+++ b/src/eg_pdf.erl
@@ -94,6 +94,7 @@
          set_title/2,
          set_word_space/2,
          skew/3,
+         svg/2, svg/3, svg/4,
          text/2,
          text_rotate/2,
          text_rotate_position/4,
@@ -557,7 +558,37 @@ image1(PID, FilePath, {size,Size})->
 	    {error, OpenError}
     end.
 
+%% @doc
+%% Inserts an SVG as a Path.
+%% svg(PID, FilePath)
+%% svg(PID, FilePath, Pos)
+%% svg(PID, FilePath, Pos, Scale)
+%% Pos is {X,Y}
+%% Scale is the scale. If the SVG uses 'mm' for the unit of its Height
+%% the SVG is scaled to points.
 
+svg(PID, FilePath) ->
+    svg(PID, FilePath, {0,0}).
+
+svg(PID, FilePath, {X,Y}) ->
+    svg(PID, FilePath, {X,Y}, 1).
+
+svg(PID, FilePath, {X,Y}, Scale) ->
+    save_state(PID),
+    case svg1(PID, FilePath, {X,Y}, Scale) of
+        {error, Reason} ->
+            {error, Reason};
+        ok ->
+            restore_state(PID)
+    end.
+
+svg1(PID, FilePath, {X,Y}, Scale) ->
+    case eg_svg2pdf:svg2pdf(PID, FilePath, X, Y, Scale) of
+        {error, Reason} ->
+            {error, Reason};
+        Stream ->
+            append_stream(PID, Stream)
+    end.
 
 %% Internals
 append_stream(PID, String)->

--- a/src/eg_pdf.erl
+++ b/src/eg_pdf.erl
@@ -448,7 +448,7 @@ text_transform(PID, A, B, C, D, E, F)->
 translate(PID, X, Y)->
     append_stream(PID, eg_pdf_op:translate(X,Y)).
 
-scale(PID, ScaleX, ScaleY) when is_integer(ScaleX), is_integer(ScaleY)->
+scale(PID, ScaleX, ScaleY)->
     append_stream(PID, eg_pdf_op:scale(ScaleX, ScaleY)).
 
 rotate(PID, Angle)->

--- a/src/eg_pdf_op.erl
+++ b/src/eg_pdf_op.erl
@@ -320,7 +320,7 @@ text_transform(A, B, C, D, E, F)->
 translate(X,Y)->
     transform(1,0,0,1,X,Y).
 
-scale(ScaleX, ScaleY) when is_integer(ScaleX), is_integer(ScaleY)->
+scale(ScaleX, ScaleY)->
     transform(ScaleX, 0, 0, ScaleY, 0, 0).
 
 rotate(90)->  " 0 1 -1 0 0 0 cm\n";

--- a/src/eg_pdf_op.erl
+++ b/src/eg_pdf_op.erl
@@ -41,6 +41,7 @@
          image1/2,
          kernedtext/1,
          line/1, line/2, line/4,
+         line_append/1,
          lines/1,
          mirror_xaxis/1, mirror_yaxis/1,
          move_to/1,

--- a/src/eg_svg2pdf.erl
+++ b/src/eg_svg2pdf.erl
@@ -1,0 +1,304 @@
+-module(eg_svg2pdf).
+-export([svg2pdf/5]).
+
+svg2pdf(_PID, FilePath, X, Y, Scale) ->
+    Svg = eg_xml_lite:parse_file(FilePath),
+    convert(Svg, [], #{posx => X, posy => Y, scale => Scale}).
+
+convert([{pi, _Encoding}|T], Acc, Ctx) ->
+    convert(T, Acc, Ctx);
+convert([{comment, _}|T], Acc, Ctx) ->
+    convert(T, Acc, Ctx);
+convert([{xml, {svg, Header, Svg}}|T], Acc, Ctx0) ->
+    Op = flip_and_size(Header, Ctx0),
+    {Res, _Ctx1} = convert_svg(Svg, [], Ctx0),
+    convert(T, [Res, Op | Acc], Ctx0);
+convert([], Acc, _Ctx) ->
+    lists:reverse(Acc).
+
+flip_and_size(Header, Ctx) ->
+    PosX = maps:get(posx, Ctx, 0),
+    PosY = maps:get(posy, Ctx, 0),
+    Scale = maps:get(scale, Ctx, 1),
+    ViewBox = proplists:get_value("viewBox", Header),
+    HeightStr = proplists:get_value("height", Header),
+    {ok, {[0, 0, _Width, Height], _}} = get_floats(4, ViewBox),
+    {ok, {[_], HeightUnit}} = get_floats(1, HeightStr),
+    case HeightUnit of
+        "" ->
+            [eg_pdf_op:translate(PosX, PosY),
+             eg_pdf_op:mirror_xaxis(Scale*Height)
+            ];
+        "mm" ->
+            %% Scale from mm to points
+            [eg_pdf_op:translate(PosX, PosY),
+             eg_pdf_op:mirror_xaxis(Scale*Height*2.83465),
+             eg_pdf_op:scale(Scale*2.83465, Scale*2.83465)
+            ]
+    end.
+
+convert_svg([{path, Path, _}|T], Acc, Ctx) ->
+    Save = eg_pdf_op:save_state(),
+    {Style, Ctx1} = style(Path, Ctx),
+    %% string:to_float will convert "0,0" to just {0, []} and not
+    %% {0, ",0"}. So we replace , with space.
+    D = no_commas(proplists:get_value("d", Path)),
+    {PathStr, _Ctx2} = convert_path(D, [], Ctx1),
+    Restore = eg_pdf_op:restore_state(),
+    convert_svg(T, [Restore, PathStr, Style, Save | Acc], Ctx1#{x => 0, y => 0});
+convert_svg([{_Tag, _, []}|T], Acc, Ctx) ->
+    convert_svg(T, Acc, Ctx);
+convert_svg([{g, Headers, Children}|T], Acc0, Ctx0) ->
+    Save = eg_pdf_op:save_state(),
+    Transform = transform(proplists:get_value("transform", Headers)),
+    {Acc1, Ctx1} = convert_svg(Children, [], Ctx0),
+    Restore = eg_pdf_op:restore_state(),
+    convert_svg(T, [Restore, Acc1, Transform, Save | Acc0], Ctx1);
+convert_svg([{_Tag, _, Children}|T], Acc0, Ctx0) ->
+    {Acc1, Ctx1} = convert_svg(Children, [], Ctx0),
+    convert_svg(T, [Acc1 | Acc0], Ctx1);
+convert_svg([{_, _}], Acc, Ctx) ->
+    {lists:reverse(Acc), maps:with([x, y], Ctx)};
+convert_svg([], Acc, Ctx) ->
+    {lists:reverse(Acc), maps:with([x, y], Ctx)}.
+
+convert_path([$M|Path], Acc, Ctx0) ->
+    {ok, {[X, Y], Rest}} = get_floats(2, Path),
+    Op = eg_pdf_op:move_to({X, Y}),
+    Ctx1 = set_start(Ctx0, X, Y),
+    convert_path(Rest, [Op | Acc], Ctx1#{x => X, y => Y, last => "L"});
+convert_path([$m|Path], Acc, #{x := X0, y := Y0} = Ctx0) ->
+    {ok, {[X1, Y1], Rest}} = get_floats(2, Path),
+    X = X1 + X0,
+    Y = Y1 + Y0,
+    Op = eg_pdf_op:move_to({X, Y}),
+    Ctx1 = set_start(Ctx0, X, Y),
+    convert_path(Rest, [Op | Acc], Ctx1#{x => X, y => Y, last => "l"});
+convert_path([$L|Path], Acc, Ctx) ->
+    {ok, {[X, Y], Rest}} = get_floats(2, Path),
+    Op = eg_pdf_op:line_append({X, Y}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X, y => Y, last => "L"});
+convert_path([$l|Path], Acc, #{x := X0, y := Y0} = Ctx) ->
+    {ok, {[X1, Y1], Rest}} = get_floats(2, Path),
+    X = X1 + X0,
+    Y = Y1 + Y0,
+    Op = eg_pdf_op:line_append({X, Y}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X, y => Y, last => "l"});
+convert_path([$H|Path], Acc, #{y := Y} = Ctx) ->
+    {ok, {[X], Rest}} = get_floats(1, Path),
+    Op = eg_pdf_op:line_append({X, Y}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X, last => "H"});
+convert_path([$h|Path], Acc, #{x := X0, y := Y} = Ctx) ->
+    {ok, {[X1], Rest}} = get_floats(1, Path),
+    X = X1 + X0,
+    Op = eg_pdf_op:line_append({X, Y}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X, last => "h"});
+convert_path([$V|Path], Acc, #{x := X} = Ctx) ->
+    {ok, {[Y], Rest}} = get_floats(1, Path),
+    Op = eg_pdf_op:line_append({X, Y}),
+    convert_path(Rest, [Op | Acc], Ctx#{y => Y, last => "V"});
+convert_path([$v|Path], Acc, #{x := X, y := Y0} = Ctx) ->
+    {ok, {[Y1], Rest}} = get_floats(1, Path),
+    Y = Y1 + Y0,
+    Op = eg_pdf_op:line_append({X, Y}),
+    convert_path(Rest, [Op | Acc], Ctx#{y => Y, last => "v"});
+convert_path([$C|Path], Acc, Ctx) ->
+    {ok, {[X1, Y1, X2, Y2, X3, Y3], Rest}} = get_floats(6, Path),
+    Op = eg_pdf_op:bezier_c({X1, Y1}, {X2, Y2}, {X3, Y3}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X3, y => Y3, last => "C"});
+convert_path([$c|Path], Acc, #{x := X0, y := Y0} = Ctx) ->
+    {ok, {[XA, YA, XB, YB, XC, YC], Rest}} = get_floats(6, Path),
+    X1 = XA + X0,
+    X2 = XB + X0,
+    X3 = XC + X0,
+    Y1 = YA + Y0,
+    Y2 = YB + Y0,
+    Y3 = YC + Y0,
+    Op = eg_pdf_op:bezier_c({X1, Y1}, {X2, Y2}, {X3, Y3}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X3, y => Y3, last => "c"});
+convert_path([$Q|Path], Acc, #{x := X0, y := Y0} = Ctx) ->
+    {ok, {[U1, V1, X3, Y3], Rest}} = get_floats(4, Path),
+    X1 = X0 + (2/3) * (U1 - X0),
+    Y1 = Y0 + (2/3) * (V1 - Y0),
+    X2 = X3 + (2/3) * (U1 - X3),
+    Y2 = Y3 + (2/3) * (V1 - Y3),
+    Op = eg_pdf_op:bezier_c({X1, Y1}, {X2, Y2}, {X3, Y3}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X3, y => Y3, last => "Q"});
+convert_path([$q|Path], Acc, #{x := X0, y := Y0} = Ctx) ->
+    {ok, {[UA, VA, XC, YC], Rest}} = get_floats(4, Path),
+    U1 = UA + X0,
+    X3 = XC + X0,
+    V1 = VA + Y0,
+    Y3 = YC + Y0,
+    X1 = X0 + (2/3) * (U1 - X0),
+    Y1 = Y0 + (2/3) * (V1 - Y0),
+    X2 = X3 + (2/3) * (U1 - X3),
+    Y2 = Y3 + (2/3) * (V1 - Y3),
+    Op = eg_pdf_op:bezier_c({X1, Y1}, {X2, Y2}, {X3, Y3}),
+    convert_path(Rest, [Op | Acc], Ctx#{x => X3, y => Y3, last => "q"});
+convert_path([$Z|Path], Acc, #{xs := X, ys := Y} = Ctx0) ->
+    Op = eg_pdf_op:path(close),
+    Ctx1 = del_start(Ctx0),
+    convert_path(chomp_space(Path), [Op | Acc],
+                 maps:without([last], Ctx1#{x => X, y => Y}));
+convert_path([$z|Path], Acc, #{xs := X, ys := Y} = Ctx0) ->
+    Op = eg_pdf_op:path(close),
+    Ctx1 = del_start(Ctx0),
+    convert_path(chomp_space(Path), [Op | Acc],
+                 maps:without([last], Ctx1#{x => X, y => Y}));
+%% Odd case of path like this seen:
+%% "M 70.828273,52.839833 65.47671,67.351551 h 10.722657 z
+convert_path([N|_] = Path, Acc, #{last := Last} = Ctx)
+  when N == $- orelse N >= $0 andalso N =< $9 ->
+    convert_path(Last ++ Path, Acc, Ctx);
+convert_path([], Acc, #{fill_rule := FillRule} = Ctx) ->
+    Op = eg_pdf_op:path(FillRule),
+    {lists:reverse([Op | Acc]), maps:with([x, y], Ctx)}.
+
+transform(undefined) ->
+    [];
+transform(TransStr) ->
+    Tokens = string:tokens(TransStr, " "),
+    parse_transform(Tokens, []).
+
+parse_transform(["translate("++Rest | Tail], Acc) ->
+    Values = no_commas(Rest),
+    {ok, {[X, Y], _}} = get_floats(2, Values),
+    Op = eg_pdf_op:translate(X, Y),
+    parse_transform(Tail, [Op | Acc]);
+parse_transform(["rotate("++Rest | Tail], Acc) ->
+    Values = no_commas(Rest),
+    {ok, [Angle], _} = get_floats(1, Values),
+    Op = eg_pdf_op:rotate(Angle),
+    parse_transform(Tail, [Op | Acc]);
+parse_transform(["scale("++Rest | Tail], Acc) ->
+    case string:tokens(Rest, ",") of
+        [XStr, YStr] ->
+            {ok, {[X], _}} = get_floats(1, XStr),
+            {ok, {[Y], _}} = get_floats(1, YStr),
+            Op = eg_pdf_op:scale(X, Y),
+            parse_transform(Tail, [Op | Acc]);
+        [XStr] ->
+            {ok, {[X], _}} = get_floats(1, XStr),
+            Op = eg_pdf_op:scale(X, X),
+            parse_transform(Tail, [Op | Acc])
+    end;
+parse_transform([], Acc) ->
+    lists:reverse(Acc).
+
+style(Path, Ctx) ->
+    case proplists:get_value("style", Path) of
+        undefined ->
+            FillColor = proplists:get_value("fill", Path, "none"),
+            StrokeColor = proplists:get_value("stroke", Path, "none"),
+            FillRule = proplists:get_value("fill-rule", Path),
+            Line = line_style(Path, []),
+            stroke_and_fill(FillColor, StrokeColor, FillRule, Line, Ctx);
+        StyleStr ->
+            Style = split_style(StyleStr),
+            FillColor = proplists:get_value("fill", Style, "none"),
+            StrokeColor = proplists:get_value("stroke", Style, "none"),
+            FillRule = proplists:get_value("fill-rule", Style),
+            Line = line_style(Style, []),
+            stroke_and_fill(FillColor, StrokeColor, FillRule, Line, Ctx)
+    end.
+
+split_style(StyleStr) ->
+    Tokens = string:tokens(StyleStr, ";"),
+    MakeProp = fun(Token) ->
+                       [K, V] = string:tokens(Token, ":"),
+                       {K, V}
+               end,
+    lists:map(MakeProp, Tokens).
+
+%% TODO: clean out old stroke colors and such if they are not set here.
+stroke_and_fill("none", "none", _, Line, Ctx) ->
+    {[Line], Ctx#{fill_rule => stroke_fill_rule(undefined, undefined, undefined)}};
+stroke_and_fill(FillColor, "none", FillRule, Line, Ctx) ->
+    {R,G,B} = get_color(FillColor),
+    {[Line, eg_pdf_op:set_fill_color_RGB(R/255, G/255, B/255)],
+     Ctx#{fill_rule => stroke_fill_rule(FillColor, undefined, FillRule)}};
+stroke_and_fill("none", StrokeColor, FillRule, Line, Ctx) ->
+    {R,G,B} = get_color(StrokeColor),
+    {[Line, eg_pdf_op:set_stroke_color_RGB(R/255, G/255, B/255),
+     eg_pdf_op:set_dash(solid)],
+     Ctx#{fill_rule => stroke_fill_rule(undefined, StrokeColor, FillRule)}};
+stroke_and_fill(FillColor, StrokeColor, FillRule, Line, Ctx) ->
+    {R1,G1,B1} = get_color(FillColor),
+    {R2,G2,B2} = get_color(StrokeColor),
+    {[Line, eg_pdf_op:set_fill_color_RGB(R1/255, G1/255, B1/255),
+      eg_pdf_op:set_stroke_color_RGB(R2/255, G2/255, B2/255),
+      eg_pdf_op:set_dash(solid)],
+     Ctx#{fill_rule => stroke_fill_rule(FillColor, StrokeColor, FillRule)}}.
+
+line_style([{"stroke-width", WidthStr} | T], Acc) ->
+    {ok, {[W], _}} = get_floats(1, WidthStr),
+    Op = eg_pdf_op:set_line_width(W),
+    line_style(T, [Op | Acc]);
+line_style([{"stroke-linecap", LineCapStr} | T], Acc) ->
+    LineCap = line_cap(LineCapStr),
+    Op = eg_pdf_op:set_line_cap(LineCap),
+    line_style(T, [Op | Acc]);
+line_style([{"stroke-linejoin", LineJoinStr} | T], Acc) ->
+    LineJoin = line_join(LineJoinStr),
+    Op = eg_pdf_op:set_line_join(LineJoin),
+    line_style(T, [Op | Acc]);
+line_style([_ | T], Acc) ->
+    line_style(T, Acc);
+line_style([], Acc) ->
+    lists:reverse(Acc).
+
+line_cap("butt") -> flat_cap;
+line_cap("round") -> round_cap;
+line_cap("square") -> square_cap.
+
+line_join("miter") -> miter_join;
+line_join("round") -> round_join;
+line_join("bevel") -> bevel_join.
+
+get_color([$#, R1, R2, G1, G2, B1, B2]) ->
+    R = list_to_integer([R1, R2], 16),
+    G = list_to_integer([G1, G2], 16),
+    B = list_to_integer([B1, B2], 16),
+    {R,G,B}.
+
+stroke_fill_rule(undefined, undefined, undefined) -> endpath;
+stroke_fill_rule(undefined, _, _) -> stroke;
+stroke_fill_rule(_, undefined, "evenodd") -> fill_even_odd;
+stroke_fill_rule(_, undefined, _) -> fill;
+stroke_fill_rule(_, _, "evenodd") -> fill_stroke_even_odd;
+stroke_fill_rule(_, _, _) -> fill_stroke.
+
+get_floats(N, Rest) ->
+    get_floats(N, chomp_space(Rest), []).
+
+get_floats(0, Rest, Acc) ->
+    {ok, {lists:reverse(Acc), Rest}};
+get_floats(N, Str, Acc) ->
+    case string:to_float(Str) of
+        {error, Reason} ->
+            case string:to_integer(Str) of
+                {error, Reason} ->
+                    error({Reason, Str});
+                {I, Rest} ->
+                    get_floats(N - 1, chomp_space(Rest), [I | Acc])
+            end;
+        {I, Rest} ->
+            get_floats(N - 1, chomp_space(Rest), [I | Acc])
+    end.
+
+chomp_space([$  | T]) ->
+    chomp_space(T);
+chomp_space([$, | T]) ->
+    chomp_space(T);
+chomp_space(Str) ->
+    Str.
+
+no_commas(Str) ->
+    lists:flatten(string:replace(Str, ",", " ", all)).
+
+set_start(#{xs := _, ys := _} = Ctx, _, _) -> Ctx;
+set_start(Ctx, X, Y) -> Ctx#{xs => X, ys => Y}.
+
+del_start(Ctx) ->
+    maps:without([xs, ys], Ctx).

--- a/src/eg_svg2pdf.erl
+++ b/src/eg_svg2pdf.erl
@@ -27,7 +27,8 @@ flip_and_size(Header, Ctx) ->
     case HeightUnit of
         "" ->
             [eg_pdf_op:translate(PosX, PosY),
-             eg_pdf_op:mirror_xaxis(Scale*Height)
+             eg_pdf_op:mirror_xaxis(Scale*Height),
+             eg_pdf_op:scale(Scale, Scale)
             ];
         "mm" ->
             %% Scale from mm to points

--- a/src/eg_svg2pdf.erl
+++ b/src/eg_svg2pdf.erl
@@ -159,31 +159,31 @@ transform(undefined) ->
     [];
 transform(TransStr) ->
     Tokens = string:tokens(TransStr, " "),
-    parse_transform(Tokens, []).
+    parse_transforms(Tokens, []).
 
-parse_transform(["translate("++Rest | Tail], Acc) ->
+parse_transforms(["translate("++Rest | Tail], Acc) ->
     Values = no_commas(Rest),
     {ok, {[X, Y], _}} = get_floats(2, Values),
     Op = eg_pdf_op:translate(X, Y),
-    parse_transform(Tail, [Op | Acc]);
-parse_transform(["rotate("++Rest | Tail], Acc) ->
+    parse_transforms(Tail, [Op | Acc]);
+parse_transforms(["rotate("++Rest | Tail], Acc) ->
     Values = no_commas(Rest),
     {ok, [Angle], _} = get_floats(1, Values),
     Op = eg_pdf_op:rotate(Angle),
-    parse_transform(Tail, [Op | Acc]);
-parse_transform(["scale("++Rest | Tail], Acc) ->
+    parse_transforms(Tail, [Op | Acc]);
+parse_transforms(["scale("++Rest | Tail], Acc) ->
     case string:tokens(Rest, ",") of
         [XStr, YStr] ->
             {ok, {[X], _}} = get_floats(1, XStr),
             {ok, {[Y], _}} = get_floats(1, YStr),
             Op = eg_pdf_op:scale(X, Y),
-            parse_transform(Tail, [Op | Acc]);
+            parse_transforms(Tail, [Op | Acc]);
         [XStr] ->
             {ok, {[X], _}} = get_floats(1, XStr),
             Op = eg_pdf_op:scale(X, X),
-            parse_transform(Tail, [Op | Acc])
+            parse_transforms(Tail, [Op | Acc])
     end;
-parse_transform([], Acc) ->
+parse_transforms([], Acc) ->
     lists:reverse(Acc).
 
 style(Path, Ctx) ->

--- a/test/images/abc.svg
+++ b/test/images/abc.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22.423513mm"
+   height="11.734655mm"
+   viewBox="0 0 22.423513 11.734655"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="test.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.9233333"
+     inkscape:cx="18.664392"
+     inkscape:cy="31.517862"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-14.703935,-12.626619)">
+    <g
+       aria-label="ABC"
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#00ff00;fill-opacity:1;stroke:none"
+       id="flowRoot10">
+      <path
+         d="M 70.828273,52.839833 65.47671,67.351551 h 10.722657 z m -2.429677,-3.886719 h 4.675771 c 0,0 8.823985,20.054772 12.738196,24.082295 6.547116,1.876496 0.806375,5.917286 -1.66419,5.280975 -2.562401,-0.659963 -6.718538,-7.683583 -6.718538,-7.683583 H 64.285304 l -2.65625,7.480469 h -4.160156 z"
+         id="path18"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccc"
+         style="fill:#00ff00" />
+      <path
+         d="m 95.214844,63.984375 v 10.683594 h 6.328126 q 3.18359,0 4.70703,-1.308594 1.54297,-1.328125 1.54297,-4.042969 0,-2.734375 -1.54297,-4.023437 -1.52344,-1.308594 -4.70703,-1.308594 z m 0,-11.992188 v 8.789063 h 5.839846 q 2.89062,0 4.29687,-1.074219 1.42578,-1.09375 1.42578,-3.320312 0,-2.207032 -1.42578,-3.300782 -1.40625,-1.09375 -4.29687,-1.09375 z M 91.269531,48.75 h 10.078129 q 4.51172,0 6.95312,1.875 2.44141,1.875 2.44141,5.332031 0,2.675781 -1.25,4.257813 -1.25,1.582031 -3.67188,1.972656 2.91016,0.625 4.51172,2.617187 1.6211,1.972657 1.6211,4.941407 0,3.90625 -2.65625,6.035156 -2.65625,2.128906 -7.5586,2.128906 H 91.269531 Z"
+         style="fill:#00ff00;stroke:#000000;stroke-opacity:1"
+         id="path20"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.82422,50.996094 v 4.160156 q -1.99219,-1.855469 -4.25781,-2.773438 -2.2461,-0.917968 -4.78516,-0.917968 -5,0 -7.65625,3.066406 -2.65625,3.046875 -2.65625,8.828125 0,5.761719 2.65625,8.828125 2.65625,3.046875 7.65625,3.046875 2.53906,0 4.78516,-0.917969 2.26562,-0.917969 4.25781,-2.773437 v 4.121093 q -2.07031,1.40625 -4.39453,2.109375 -2.30469,0.703125 -4.88282,0.703125 -6.62109,0 -10.42968,-4.042968 -3.8086,-4.0625 -3.8086,-11.074219 0,-7.03125 3.8086,-11.074219 3.80859,-4.0625 10.42968,-4.0625 2.61719,0 4.92188,0.703125 2.32422,0.683594 4.35547,2.070313 z"
+         style="fill:none;stroke:#000000;stroke-opacity:1"
+         id="path22"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14.83243,22.38507 c 0,0 0.644888,2.633294 3.493145,1.612221 2.848257,-1.021073 7.416215,-0.322444 7.416215,-0.322444 l -0.107481,-1.827183"
+       id="path830"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/test/svg_test.erl
+++ b/test/svg_test.erl
@@ -1,0 +1,15 @@
+-module(svg_test).
+-include_lib("eunit/include/eunit.hrl").
+
+run_test()->
+    ?debugMsg("Begin Test"),
+    PDF = eg_pdf:new(),
+    eg_pdf:set_pagesize(PDF, a4),
+    eg_pdf_lib:showGrid(PDF, a4),
+    SvgFilepath1 = filename:join([code:priv_dir(erlguten), "..", "test",
+                                  "images", "abc.svg"]),
+    eg_pdf:svg(PDF, SvgFilepath1, {25, 750}),
+    eg_pdf:svg(PDF, SvgFilepath1, {100, 600}, 4),
+    {Serialised, _PageNo} = eg_pdf:export(PDF),
+    file:write_file("./svg_test.pdf",[Serialised]),
+    eg_pdf:delete(PDF).


### PR DESCRIPTION
This adds an initial SVG support of converting SVG paths to PDF paths.

It needs non-integer scaling to get the scaling from mm to points correct.

It does not include a lot of documentation since your master and the hex packet has diverged a lot when it comes to docs.
